### PR TITLE
fix: jj config isn't there for osx

### DIFF
--- a/home/jj.nix
+++ b/home/jj.nix
@@ -1,14 +1,16 @@
 { config, pkgs, ... }:
-
-
+let
+template = builtins.readFile ./jj/default-description.template;
+in
 {
-  config = {
-    home.packages = with pkgs; [ jujutsu meld ];
-
-    xdg.configFile."jj/config.toml".text = ''
-      [user]
-      name = "Elliott Clark"
-      email = "elliott@batteriesincl.com"
-    '';
-  };
+    programs = {
+      jujutsu = {
+        enable = true;
+        settings = {
+          user.name = "Elliott Clark";
+          user.email = "elliott@batteriesincl.com";
+          ui.default-description = template;
+        };
+      };
+    };
 }

--- a/home/jj/default-description.template
+++ b/home/jj/default-description.template
@@ -1,0 +1,24 @@
+JJ: Title: type(<area scope>): summary of the changes that you have made
+JJ: No more than 80 chars
+
+JJ: Remember the blank line
+
+Summary:
+
+Test Plan:
+
+JJ: /End
+JJ:
+JJ: Some Reasonable change types
+JJ:
+JJ: - feat
+JJ: - fix
+JJ: - refactor
+JJ: - perf
+JJ: - style
+JJ: - test
+JJ: - docs
+JJ: - build
+JJ: - chore
+JJ:
+JJ: Area Scope is optional


### PR DESCRIPTION
Summary:
darwin has a different location, so use the provided flake install. It knows where to put this.

Test Plan:
`jj config g user.email`
